### PR TITLE
Add Hardhat, Ethers.js and TypeChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ article but useful to solidify your knowledge). (Est. time: 26 minutes)
 1. Read [How does Ethereum work, anyway?](https://medium.com/@preethikasireddy/how-does-ethereum-work-anyway-22d1df506369) (Est. time: 38 minutes)
 2. Read [this article](https://blog.zeppelin.solutions/the-hitchhikers-guide-to-smart-contracts-in-ethereum-848f08001f05)
 on smart contracts development. (Est. time: 15 minutes)
-3. Read the [Truffle Documentation](https://truffleframework.com/docs/)
-4. Read the [Web3 Documentation](https://web3js.readthedocs.io/en/1.0/)
+3. Read the [Truffle Documentation](https://truffleframework.com/docs/) / [Hardhat Documentation](https://hardhat.org/getting-started/)
+4. Read the [Web3 Documentation](https://web3js.readthedocs.io/en/1.0/) / [Ethers Documentation](https://docs.ethers.io/v5/)
 5. Book [Mastering Ethereum](https://github.com/ethereumbook/ethereumbook)
 
 #### Practice
@@ -105,6 +105,7 @@ List of tools curated by Protofire team to better apply best practices to the Pr
 - [solium](https://github.com/duaraghav8/Solium) - Linter to identify and fix style & security issues in Solidity smart contracts.
 - [sol-tester](https://github.com/androlo/sol-tester) - Utilities for building, linking and testing contracts using go-ethereum and the simulated chain.
 - [solidity-coverage](https://github.com/sc-forks/solidity-coverage) - Code coverage tool.
+- [TypeChain](https://github.com/ethereum-ts/TypeChain) - TypeScript bindings for Ethereum Smart Contracts.
 
 ## Miscellaneous
 


### PR DESCRIPTION
Mentions [Hardhat](https://github.com/nomiclabs/hardhat) as an alternative for Truffle and [Ethers.js](https://github.com/ethers-io/ethers.js) as alternative of Web3.js. Also adds [Typechain](https://github.com/ethereum-ts/TypeChain) as a utility tool.

Pls let me know if changes needed